### PR TITLE
index.tsの'use strict'を削除

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -1,4 +1,3 @@
-'use strict';
 import {client, TrashData} from "trash-common"
 import {DisplayCreator} from "./display-creator"
 


### PR DESCRIPTION
・スキル審査で「今後リクエストが拡張された場合にエラーになる」という理由で不合格
・https://forums.developer.amazon.com/questions/2848/-alexa-skills-kit-may-add-new-properties-to-the-js.htmlによれば'use strict'削除で通った人がいる
・https://github.com/alexa/skill-sample-controls-hello-world/blob/master/lambda/index.jsのサンプルコードに'use -strict'なし